### PR TITLE
feat: logging levels

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -1,5 +1,3 @@
-# Configuration
-
 GraphAI can be configured using environment variables to customize behavior and output.
 
 ## Environment Variables

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -1,0 +1,53 @@
+# Configuration
+
+GraphAI can be configured using environment variables to customize behavior and output.
+
+## Environment Variables
+
+### GRAPHAI_LOG_LEVEL
+
+Controls the logging output level for GraphAI components. This is useful for debugging or reducing log verbosity in production environments.
+
+**Available levels:**
+- `DEBUG` - Show all messages (most verbose)
+- `INFO` - Show info, warning, error, critical messages (default)
+- `WARNING` - Show warning, error, critical messages  
+- `ERROR` - Show only error and critical messages
+- `CRITICAL` - Show only critical messages
+
+**Usage:**
+
+```bash
+# Hide warning messages (e.g., missing docstrings in functions)
+export GRAPHAI_LOG_LEVEL=ERROR
+
+# Show debug information for troubleshooting
+export GRAPHAI_LOG_LEVEL=DEBUG
+
+# Set for a single command
+GRAPHAI_LOG_LEVEL=WARNING python my_script.py
+```
+
+**Example:**
+
+If you're seeing warnings like:
+```
+2025-08-16 13:41:54 WARNING graphai.utils Function start has no docstring
+```
+
+You can suppress them by setting:
+```bash
+export GRAPHAI_LOG_LEVEL=ERROR
+```
+
+## Default Values
+
+| Environment Variable | Default Value | Description |
+|---------------------|---------------|-------------|
+| `GRAPHAI_LOG_LEVEL` | `INFO` | Controls logging verbosity |
+
+## Best Practices
+
+- **Development**: Use `DEBUG` or `INFO` level to see detailed information
+- **Production**: Use `WARNING` or `ERROR` level to reduce log noise
+- **CI/CD**: Use `ERROR` level to only show important issues

--- a/docs/user-guide/release-notes.md
+++ b/docs/user-guide/release-notes.md
@@ -5,6 +5,7 @@ See below for all notable changes to the GraphAI library.
 ### Added
 - Graph constructor methods [`add_node`, `add_router`, `add_edge`, `set_callback`, `set_state`, `update_state`, `reset_state`, `set_start_node`, `set_end_node`, `compile`] can now be chained
 - Moved `Callback` class to top-level import, you can now import it with `from graphai import Callback`
+- Environment variable `GRAPHAI_LOG_LEVEL` for controlling log output level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
 
 ### Changed
 - Dropped `networkx`, `matplotlib`, and `colorlog` dependencies (note if using `Graph.visualize` one of `networkx` or `matplotlib` must be installed)

--- a/graphai/utils.py
+++ b/graphai/utils.py
@@ -1,4 +1,5 @@
 import inspect
+import os
 from typing import Any, Callable
 from pydantic import BaseModel, Field
 import logging
@@ -49,7 +50,17 @@ def setup_custom_logger(name):
 
     if not logger.hasHandlers():
         add_coloured_handler(logger)
-        logger.setLevel(logging.INFO)
+        
+        # Set log level from environment variable, default to INFO
+        log_level = os.getenv("GRAPHAI_LOG_LEVEL", "INFO").upper()
+        level_map = {
+            "DEBUG": logging.DEBUG,
+            "INFO": logging.INFO,
+            "WARNING": logging.WARNING,
+            "ERROR": logging.ERROR,
+            "CRITICAL": logging.CRITICAL,
+        }
+        logger.setLevel(level_map.get(log_level, logging.INFO))
         logger.propagate = False
 
     return logger


### PR DESCRIPTION
This pull request introduces support for configuring the logging verbosity of GraphAI via the new `GRAPHAI_LOG_LEVEL` environment variable. This allows users to easily control the amount of log output for debugging, production, and CI/CD environments. The changes include documentation updates, release notes, and code modifications to read and apply the log level from the environment.

**Logging configuration improvements:**

* Added support for the `GRAPHAI_LOG_LEVEL` environment variable in `graphai/utils.py`, allowing users to set the log level (DEBUG, INFO, WARNING, ERROR, CRITICAL) dynamically.
* Updated `graphai/utils.py` to import `os` for reading environment variables.

**Documentation updates:**

* Added a new section to `docs/guides/configuration.md` detailing how to use the `GRAPHAI_LOG_LEVEL` environment variable, including usage examples and best practices.
* Updated the release notes in `docs/user-guide/release-notes.md` to mention the addition of `GRAPHAI_LOG_LEVEL` for controlling log output level.