### PR TITLE
feat: add function schema support for openai responses api

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "graphai-lib"
-version = "0.0.8"
+version = "0.0.9rc1"
 description = "Not an AI framework"
 readme = "README.md"
 requires-python = ">=3.10,<3.14"

--- a/tests/unit/test_function_schema.py
+++ b/tests/unit/test_function_schema.py
@@ -42,3 +42,22 @@ def test_function_schema_to_dict():
         is None
     )
     assert dict_schema["function"]["parameters"]["required"] == ["url"]
+
+
+def test_function_schema_to_openai_responses():
+    schema = FunctionSchema.from_callable(scrape_webpage)
+    openai_responses_schema = schema.to_openai(api="responses")
+    
+    # Check that the structure is different from to_dict()
+    assert openai_responses_schema["type"] == "function"
+    assert openai_responses_schema["name"] == schema.name
+    assert openai_responses_schema["description"] == schema.description
+    
+    # Check parameters structure
+    assert openai_responses_schema["parameters"]["type"] == "object"
+    assert openai_responses_schema["parameters"]["properties"]["url"]["type"] == "string"
+    assert openai_responses_schema["parameters"]["properties"]["name"]["type"] == "string"
+    assert openai_responses_schema["parameters"]["required"] == ["url"]
+    
+    # Verify it doesn't have the nested "function" key like to_dict()
+    assert "function" not in openai_responses_schema

--- a/uv.lock
+++ b/uv.lock
@@ -437,7 +437,7 @@ wheels = [
 
 [[package]]
 name = "graphai-lib"
-version = "0.0.8"
+version = "0.0.9rc1"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
This pull request introduces support for multiple OpenAI-compatible function schema formats and improves type safety and usability in the `graphai/utils.py` module. The main changes include adding an enum to specify OpenAI API types, updating the schema conversion logic to handle both "completions" and "responses" formats, and enhancing tests to verify the new functionality.

**OpenAI API format support:**
* Added the `OpenAIAPI` `StrEnum` to represent supported API formats ("completions" and "responses") in `graphai/utils.py`.
* Updated the `FunctionSchema.to_openai` method to accept an `api` parameter and return the schema in either "completions" or "responses" format, raising an error for unrecognized formats.

**Type safety and usability improvements:**
* Improved type annotations for schema conversion methods, including the return type for `FunctionSchema.to_dict` and `get_schemas`. [[1]](diffhunk://#diff-6c7bc4c1a52d7e234447b842450a2e0f607a743b10d24a4d998e5c66cd6a1d56L192-R196) [[2]](diffhunk://#diff-6c7bc4c1a52d7e234447b842450a2e0f607a743b10d24a4d998e5c66cd6a1d56L213-R252)

**Testing enhancements:**
* Added a new unit test to verify the structure and correctness of the "responses" format returned by `FunctionSchema.to_openai`.

**Version update:**
* Bumped the package version to `0.0.9rc1` in `pyproject.toml` to reflect the new functionality.