### PR TITLE
fix: allow cycles

### DIFF
--- a/graphai/graph.py
+++ b/graphai/graph.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
-from typing import Any, Protocol, Type
-from graphlib import TopologicalSorter, CycleError
+from typing import Any, Protocol 
 from graphai.callback import Callback
 from graphai.utils import logger
 
@@ -63,7 +62,7 @@ class Graph:
         self.edges: list[Any] = []
         self.start_node: NodeProtocol | None = None
         self.end_nodes: list[NodeProtocol] = []
-        self.Callback: Type[Callback] = Callback
+        self.Callback: type[Callback] = Callback
         self.max_steps = max_steps
         self.state = initial_state or {}
 
@@ -288,17 +287,6 @@ class Graph:
                     "(src, Iterable[dst]), mapping{'source'/'destination'}, or objects with .source/.destination"
                 )
 
-        # cycle detection
-        preds: dict[str, set[str]] = {n: set() for n in nodes.keys()}
-        for s, ds in adj.items():
-            for d in ds:
-                preds[d].add(s)
-
-        try:
-            list(TopologicalSorter(preds).static_order())
-        except CycleError as e:
-            raise GraphCompileError("Cycle detected in graph") from e
-
         # reachability from start
         seen: set[str] = set()
         stack = [start_name]
@@ -388,7 +376,7 @@ class Graph:
         as the default callback when no callback is passed to the `execute` method.
 
         :param callback_class: The callback class to use as the default callback.
-        :type callback_class: Type[Callback]
+        :type callback_class: type[Callback]
         """
         self.Callback = callback_class
         return self

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "graphai-lib"
-version = "0.0.9rc1"
+version = "0.0.9rc2"
 description = "Not an AI framework"
 readme = "README.md"
 requires-python = ">=3.10,<3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -437,7 +437,7 @@ wheels = [
 
 [[package]]
 name = "graphai-lib"
-version = "0.0.9rc1"
+version = "0.0.9rc2"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
This pull request primarily updates the `graphai/graph.py` module by refining type annotations and removing cycle detection logic from the `_add_edge` method. Additionally, it bumps the package version in `pyproject.toml`. The most important changes are grouped below:

Type annotation improvements:
* Updated type hints from `Type[Callback]` to `type[Callback]` in both the `__init__` method and the `set_callback` method to use the preferred Python syntax for class types. [[1]](diffhunk://#diff-9cb342f3e399e212a3dec2768cccf009742e9ec8c92a6156472d19ebbfeb4697L66-R65) [[2]](diffhunk://#diff-9cb342f3e399e212a3dec2768cccf009742e9ec8c92a6156472d19ebbfeb4697L391-R379)

Graph logic changes:
* Removed the cycle detection code using `TopologicalSorter` and `CycleError` from the `_add_edge` method, which means the graph will no longer check for cycles during edge addition.

Package metadata update:
* Bumped the package version from `0.0.9rc1` to `0.0.9rc2` in `pyproject.toml`.

Imports cleanup:
* Removed unused imports (`Type` and `CycleError`) from the top of `graphai/graph.py`.