### PR TITLE
feat: object events

### DIFF
--- a/docs/user-guide/release-notes.md
+++ b/docs/user-guide/release-notes.md
@@ -1,5 +1,29 @@
 See below for all notable changes to the GraphAI library.
 
+## [0.0.9] - TBD
+
+### Added
+- Enhanced `FunctionSchema.from_pydantic()` method with full Pydantic v2 support
+  - Correctly extracts field types, descriptions, and default values from Pydantic models
+  - Handles `Optional` types and complex type annotations
+  - Properly identifies required vs optional fields using `PydanticUndefined`
+- New `to_openai()` method on FunctionSchema for OpenAI API format support
+  - Supports both `completions` and `responses` API endpoints
+  - Export schemas for either nested or flat format structures
+- Comprehensive graph compilation validation
+  - Stricter validation of node connections and dependencies
+  - Better error messages for graph construction issues
+  - Cycle detection with clear `GraphCompileError` reporting
+
+### Changed
+- Graph compilation now validates execution order at compile time
+- Graphs with cycles now raise `GraphCompileError` during compilation to ensure predictable execution order
+
+### Fixed
+- Added Python 3.10 compatibility for `StrEnum` with fallback implementation
+- Fixed type annotation issues with `default_factory` in Pydantic field definitions
+- Improved type extraction for complex Pydantic field types including `Union` and `Optional`
+
 ## [0.0.8] - 2025-08-16
 
 ### Added

--- a/docs/user-guide/release-notes.md
+++ b/docs/user-guide/release-notes.md
@@ -10,6 +10,11 @@ See below for all notable changes to the GraphAI library.
 - New `to_openai()` method on FunctionSchema for OpenAI API format support
   - Supports both `completions` and `responses` API endpoints
   - Export schemas for either nested or flat format structures
+- New `EventCallback` class for object-based callback handling
+  - Outputs structured `GraphEvent` objects instead of formatted strings
+  - Provides `GraphEventType` enum for event type identification
+  - Better structured data with `type`, `identifier`, `token`, and `params` fields
+  - Maintains backward compatibility with existing callback interface
 - Comprehensive graph compilation validation
   - Stricter validation of node connections and dependencies
   - Better error messages for graph construction issues
@@ -18,6 +23,10 @@ See below for all notable changes to the GraphAI library.
 ### Changed
 - Graph compilation now validates execution order at compile time
 - Graphs with cycles now raise `GraphCompileError` during compilation to ensure predictable execution order
+
+### Deprecated
+- `Callback` class is deprecated and will be removed in v0.1.0 - use `EventCallback` instead
+- `special_token_format` and `token_format` parameters in `EventCallback` exist for backwards compatibility but are deprecated and will be removed in v0.1.0
 
 ### Fixed
 - Added Python 3.10 compatibility for `StrEnum` with fallback implementation

--- a/graphai/callback.py
+++ b/graphai/callback.py
@@ -258,7 +258,7 @@ class EventCallback(Callback):
         warnings.warn(
             "The `special_token_format` and `token_format` parameters are " +
             "deprecated and will be removed in v0.1.0.",
-            DeprecatedWarning
+            DeprecationWarning
         )
         if special_token_format is None:
             special_token_format = "<{identifier}:{token}:{params}>"

--- a/graphai/callback.py
+++ b/graphai/callback.py
@@ -12,7 +12,7 @@ log_stream = True
 
 class StrEnum(Enum):
     def __str__(self) -> str:
-        return self.value
+        return str(self.value)
 
 class GraphEventType(StrEnum):
     START = "start"
@@ -271,20 +271,20 @@ class EventCallback(Callback):
         if self._done:
             raise RuntimeError("Cannot add tokens to a closed stream")
         self._check_node_name(node_name=node_name)
-        token = GraphEvent(type=GraphEventType.CALLBACK, identifier=self.identifier, token=token, params=None)
+        event = GraphEvent(type=GraphEventType.CALLBACK, identifier=self.identifier, token=token, params=None)
         # otherwise we just assume node is correct and send token
-        self.queue.put_nowait(token)
+        self.queue.put_nowait(event)
 
     async def acall(self, token: str, node_name: str | None = None):
         # TODO JB: do we need to have `node_name` param?
         if self._done:
             raise RuntimeError("Cannot add tokens to a closed stream")
         self._check_node_name(node_name=node_name)
-        token = GraphEvent(type=GraphEventType.CALLBACK, identifier=self.identifier, token=token, params=None)
+        event = GraphEvent(type=GraphEventType.CALLBACK, identifier=self.identifier, token=token, params=None)
         # otherwise we just assume node is correct and send token
-        self.queue.put_nowait(token)
+        self.queue.put_nowait(event)
 
-    async def aiter(self) -> AsyncIterator[str]:
+    async def aiter(self) -> AsyncIterator[GraphEvent]:  # type: ignore[override]
         """Used by receiver to get the tokens from the stream queue. Creates
         a generator that yields tokens from the queue until the END token is
         received.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "graphai-lib"
-version = "0.0.9rc2"
+version = "0.0.9rc3"
 description = "Not an AI framework"
 readme = "README.md"
 requires-python = ">=3.10,<3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -437,7 +437,7 @@ wheels = [
 
 [[package]]
 name = "graphai-lib"
-version = "0.0.9rc2"
+version = "0.0.9rc3"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
This pull request introduces a major update to the callback system in the GraphAI library, replacing the legacy string-based `Callback` class with a new, object-oriented `EventCallback` class and structured `GraphEvent` objects. It also adds a comprehensive suite of tests for the new event-driven callback logic, improves deprecation warnings, and updates documentation to reflect these changes. Additionally, the version is bumped to `0.0.9rc3`.

**Callback System Modernization**
* Added `EventCallback` class, which emits structured `GraphEvent` objects with typed fields for event handling, and introduced the `GraphEventType` enum for event type identification. This replaces the legacy string-based `Callback` mechanism. (`graphai/callback.py` [[1]](diffhunk://#diff-8fb995748407629acebcf81198af28867e7fa11b90b8a63e3327aff4e8bd9092R3-R35) [[2]](diffhunk://#diff-d5d89b7bafe46a42f2a021d93aa0d290839858474573097cfeff52813b519c29R2-R50) [[3]](diffhunk://#diff-d5d89b7bafe46a42f2a021d93aa0d290839858474573097cfeff52813b519c29R246-R342)
* Deprecated the original `Callback` class and its string formatting parameters, with clear deprecation warnings to guide migration to the new system. (`graphai/callback.py` [[1]](diffhunk://#diff-d5d89b7bafe46a42f2a021d93aa0d290839858474573097cfeff52813b519c29R110-R114) [[2]](diffhunk://#diff-8fb995748407629acebcf81198af28867e7fa11b90b8a63e3327aff4e8bd9092R3-R35)

**Testing and Validation**
* Added extensive unit tests for the new `EventCallback` and `GraphEvent` logic, covering initialization, event creation, async iteration, node lifecycle, and error handling. (`tests/unit/test_callback.py` [[1]](diffhunk://#diff-bd3a1da40ac6e459e4c8c79b6b1297e719812598f3bcf89e6ab59a57644f504cR4) [[2]](diffhunk://#diff-bd3a1da40ac6e459e4c8c79b6b1297e719812598f3bcf89e6ab59a57644f504cR208-R382)

**Documentation and Release Notes**
* Updated release notes to document the new callback system, deprecations, and other improvements for the upcoming `0.0.9` release. (`docs/user-guide/release-notes.md` [docs/user-guide/release-notes.mdR3-R35](diffhunk://#diff-8fb995748407629acebcf81198af28867e7fa11b90b8a63e3327aff4e8bd9092R3-R35))

**Versioning**
* Bumped the library version to `0.0.9rc3` for this release. (`pyproject.toml` [pyproject.tomlL3-R3](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3))