### PR TITLE
Parallel execution of graph nodes

### DIFF
--- a/graphai/graph.py
+++ b/graphai/graph.py
@@ -3,6 +3,7 @@ from typing import Any, Protocol
 from graphlib import TopologicalSorter, CycleError
 from graphai.callback import Callback
 from graphai.utils import logger
+import asyncio
 
 
 # to fix mypy error
@@ -322,57 +323,87 @@ class Graph:
                 f"Instead, got {type(output)} from '{output}'."
             )
 
-    async def execute(self, input, callback: Callback | None = None):
+    def _get_next_nodes(self, current_node: NodeProtocol) -> list[NodeProtocol]:
+        """Return all successor nodes for the given node."""
+        return [edge.destination for edge in self.edges if edge.source == current_node]
+
+    async def _invoke_node(
+        self, node: NodeProtocol, state: dict[str, Any], callback: Callback
+    ):
+        if node.stream:
+            await callback.start_node(node_name=node.name)
+            output = await node.invoke(input=state, callback=callback, state=self.state)
+            self._validate_output(output=output, node_name=node.name)
+            await callback.end_node(node_name=node.name)
+        else:
+            output = await node.invoke(input=state, state=self.state)
+            self._validate_output(output=output, node_name=node.name)
+        return output
+
+    async def _execute_branch(
+        self,
+        current_node: NodeProtocol,
+        state: dict[str, Any],
+        callback: Callback,
+        steps: int,
+    ):
+        """Recursively execute a branch starting from `current_node`.
+        When a node has multiple successors, run them concurrently and merge their outputs."""
+        while True:
+            output = await self._invoke_node(current_node, state, callback)
+            state = {**state, **output}  # merge node output into local state
+            if current_node.is_end:
+                break
+            if current_node.is_router:
+                next_node_name = str(output["choice"])
+                del output["choice"]
+                current_node = self._get_node_by_name(node_name=next_node_name)
+                continue
+
+            next_nodes = self._get_next_nodes(current_node)
+            if not next_nodes:
+                raise Exception(
+                    f"No outgoing edge found for current node '{current_node.name}'."
+                )
+            if len(next_nodes) == 1:
+                current_node = next_nodes[0]
+            else:
+                # Run each branch concurrently
+                results = await asyncio.gather(
+                    *[
+                        self._execute_branch(n, state.copy(), callback, steps + 1)
+                        for n in next_nodes
+                    ]
+                )
+                merged = state.copy()
+                for res in results:
+                    # merge states returned by each branch
+                    for k, v in res.items():
+                        if k != "callback":
+                            merged[k] = v
+                return merged
+            steps += 1
+            if steps >= self.max_steps:
+                raise Exception(
+                    f"Max steps reached: {self.max_steps}. You can modify this by setting `max_steps` when initializing the Graph object."
+                )
+        return state
+
+    async def execute(self, input: dict[str, Any], callback: Callback | None = None):
         # TODO JB: may need to add init callback here to init the queue on every new execution
         if callback is None:
             callback = self.get_callback()
 
         # Type assertion to tell the type checker that start_node is not None after compile()
         assert self.start_node is not None, "Graph must be compiled before execution"
-        current_node = self.start_node
 
         state = input
-        # Don't reset the graph state if it was initialized with initial_state
-        steps = 0
-        while True:
-            # we invoke the node here
-            if current_node.stream:
-                # add callback tokens and param here if we are streaming
-                await callback.start_node(node_name=current_node.name)
-                # Include graph's internal state in the node execution context
-                output = await current_node.invoke(
-                    input=state, callback=callback, state=self.state
-                )
-                self._validate_output(output=output, node_name=current_node.name)
-                await callback.end_node(node_name=current_node.name)
-            else:
-                # Include graph's internal state in the node execution context
-                output = await current_node.invoke(input=state, state=self.state)
-                self._validate_output(output=output, node_name=current_node.name)
-            # add output to state
-            state = {**state, **output}
-            if current_node.is_end:
-                # finish loop if this was an end node
-                break
-            if current_node.is_router:
-                # if we have a router node we let the router decide the next node
-                next_node_name = str(output["choice"])
-                del output["choice"]
-                current_node = self._get_node_by_name(node_name=next_node_name)
-            else:
-                # otherwise, we have linear path
-                current_node = self._get_next_node(current_node=current_node)
-            steps += 1
-            if steps >= self.max_steps:
-                raise Exception(
-                    f"Max steps reached: {self.max_steps}. You can modify this "
-                    "by setting `max_steps` when initializing the Graph object."
-                )
+        result = await self._execute_branch(self.start_node, state, callback, 0)
         # TODO JB: may need to add end callback here to close the queue for every execution
-        if callback and "callback" in state:
+        if callback and "callback" in result:
             await callback.close()
-            del state["callback"]
-        return state
+            del result["callback"]
+        return result
 
     def get_callback(self):
         """Get a new instance of the callback class.
@@ -417,6 +448,14 @@ class Graph:
         raise Exception(
             f"No outgoing edge found for current node '{current_node.name}'."
         )
+
+    def add_parallel(
+        self, source: NodeProtocol | str, destinations: list[NodeProtocol | str]
+    ):
+        """Add multiple outgoing edges from a single source node to be executed in parallel."""
+        for dest in destinations:
+            self.add_edge(source, dest)
+        return self
 
     def visualize(self, *, save_path: str | None = None):
         """Render the current graph. If matplotlib is not installed,

--- a/tests/unit/test_graph_parallel.py
+++ b/tests/unit/test_graph_parallel.py
@@ -1,0 +1,155 @@
+import pytest
+from graphai import node, router, Graph
+
+
+@pytest.mark.asyncio
+async def test_parallel_branches_merge_state():
+    """Two successors from a single node should run concurrently and merge results."""
+
+    @node(start=True)
+    async def start(input: dict):
+        return {}
+
+    @node
+    async def branch_a(input: dict):
+        return {"a": 1}
+
+    @node
+    async def branch_b(input: dict):
+        return {"b": 2}
+
+    @node(end=True)
+    async def end(input: dict):
+        return {}
+
+    g = Graph()
+    # add nodes
+    g.add_node(start).add_node(branch_a).add_node(branch_b).add_node(end)
+    # define edges so start branches to A and B in parallel
+    g.add_edge(start, branch_a)
+    g.add_edge(start, branch_b)
+    # both branches lead to a common end
+    g.add_edge(branch_a, end)
+    g.add_edge(branch_b, end)
+
+    result = await g.execute(input={"input": {}})
+    # both branch outputs should be present in the final state
+    assert result.get("a") == 1
+    assert result.get("b") == 2
+
+
+@pytest.mark.asyncio
+async def test_parallel_nested_branches():
+    """Nested parallel execution (branching at multiple levels) should merge all results."""
+
+    @node(start=True)
+    async def start(input: dict):
+        return {}
+
+    @node
+    async def mid(input: dict):
+        return {"mid": True}
+
+    @node
+    async def branch_a(input: dict):
+        return {"a": 1}
+
+    @node
+    async def branch_b(input: dict):
+        return {"b": 2}
+
+    @node(end=True)
+    async def end(input: dict):
+        return {}
+
+    g = Graph()
+    g.add_node(start).add_node(mid).add_node(branch_a).add_node(branch_b).add_node(end)
+    # linear edge to mid
+    g.add_edge(start, mid)
+    # mid forks to two branches
+    g.add_edge(mid, branch_a)
+    g.add_edge(mid, branch_b)
+    # both branches go to end
+    g.add_edge(branch_a, end)
+    g.add_edge(branch_b, end)
+
+    result = await g.execute(input={"input": {}})
+    assert result["mid"] is True
+    assert result["a"] == 1
+    assert result["b"] == 2
+
+
+@pytest.mark.asyncio
+async def test_add_parallel():
+    """The add_parallel convenience method should wire up multiple edges for concurrent execution."""
+
+    @node(start=True)
+    async def start(input: dict):
+        return {}
+
+    @node
+    async def branch_a(input: dict):
+        return {"a": 1}
+
+    @node
+    async def branch_b(input: dict):
+        return {"b": 2}
+
+    @node(end=True)
+    async def end(input: dict):
+        return {}
+
+    g = Graph()
+    g.add_node(start).add_node(branch_a).add_node(branch_b).add_node(end)
+    # use the new helper to branch in parallel
+    g.add_parallel(start, [branch_a, branch_b])
+    g.add_edge(branch_a, end)
+    g.add_edge(branch_b, end)
+
+    result = await g.execute(input={"input": {}})
+    assert result["a"] == 1
+    assert result["b"] == 2
+
+
+@pytest.mark.asyncio
+async def test_router_node_not_parallel():
+    """A router node should still choose one successor, not branch in parallel."""
+
+    @node(start=True)
+    async def start(input: dict):
+        return {}
+
+    @router
+    async def chooser(input: dict):
+        # always choose branch_a
+        return {"choice": "branch_a"}
+
+    @node(name="branch_a")
+    async def branch_a(input: dict):
+        return {"a": 1}
+
+    @node(name="branch_b")
+    async def branch_b(input: dict):
+        return {"b": 2}
+
+    @node(end=True)
+    async def end(input: dict):
+        return {}
+
+    g = Graph()
+    g.add_node(start).add_node(chooser).add_node(branch_a).add_node(branch_b).add_node(
+        end
+    )
+    # linear to router
+    g.add_edge(start, chooser)
+    # router can go to either branch, but chooser selects 'branch_a'
+    g.add_edge(chooser, branch_a)
+    g.add_edge(chooser, branch_b)
+    # both branches connect to end
+    g.add_edge(branch_a, end)
+    g.add_edge(branch_b, end)
+
+    result = await g.execute(input={"input": {}})
+    # only branch_a should run; branch_b's output should not appear
+    assert result.get("a") == 1
+    assert "b" not in result


### PR DESCRIPTION
This PR introduces native support for parallel execution of graph branches and adds a convenience method for explicitly defining parallel successors.

Parallel branch execution:
The Graph now detects when a node has more than one outgoing edge and will run each branch concurrently via asyncio.gather, merging their outputs back into a single state. Nested parallelism is supported, and existing router behaviour (choosing a single successor via the "choice" key) remains unchanged.

New helper – add_parallel()
To make it explicit when multiple successors should be treated as parallel, Graph.add_parallel(source, destinations) wraps multiple add_edge calls. When executing, any node with more than one successor will automatically be run in parallel.

Internal refactoring:

Added _get_next_nodes() to return all successors of a node.

Added _invoke_node() to handle callback start/stop and streaming logic in one place.

Added a recursive _execute_branch() that walks a branch, spawns concurrent tasks for parallel branches, and merges their results.

Updated execute() to delegate to _execute_branch() and to clean up callbacks correctly at the end.