### PR TITLE
feat: improved event callback

### DIFF
--- a/docs/user-guide/release-notes.md
+++ b/docs/user-guide/release-notes.md
@@ -15,6 +15,14 @@ See below for all notable changes to the GraphAI library.
 - New `add_parallel()` convenience method for creating parallel branches
   - Syntactic sugar for adding multiple edges from one source to multiple destinations
 
+### Changed
+- Enhanced `EventCallback.__call__()` and `EventCallback.acall()` method signatures
+  - Removed legacy `node_name` parameter for cleaner API
+  - Added `type` parameter to specify event type directly (defaults to `GraphEventType.CALLBACK`)
+  - Added `identifier` parameter for custom event identification
+  - Added `params` parameter for event metadata
+  - Improved flexibility for custom event handling and streaming
+
 ## [0.0.9] - 2025-09-05
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "graphai-lib"
-version = "0.0.10rc2"
+version = "0.0.10rc3"
 description = "Not an AI framework"
 readme = "README.md"
 requires-python = ">=3.10,<3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -437,7 +437,7 @@ wheels = [
 
 [[package]]
 name = "graphai-lib"
-version = "0.0.10rc2"
+version = "0.0.10rc3"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
This pull request introduces a significant update to the event handling API in the GraphAI library, focusing on improving the flexibility and clarity of the `EventCallback` class and related event interfaces. The legacy `node_name` parameter has been removed from callback methods, and new parameters have been added to allow for more customizable event handling and streaming. Additionally, the event type system has been expanded to support custom event types, and a protocol for callback handlers has been introduced for better type safety and extensibility.

### EventCallback API enhancements

* Removed the legacy `node_name` parameter from `EventCallback.__call__()` and `EventCallback.acall()` methods, simplifying the API and reducing confusion. [[1]](diffhunk://#diff-8fb995748407629acebcf81198af28867e7fa11b90b8a63e3327aff4e8bd9092R18-R25) [[2]](diffhunk://#diff-d5d89b7bafe46a42f2a021d93aa0d290839858474573097cfeff52813b519c29L280-R367)
* Added new parameters to `EventCallback.__call__()` and `EventCallback.acall()`: `type` (for specifying event type, supporting both `GraphEventType` and custom strings), `identifier` (for custom event identification), and `params` (for event metadata), greatly improving flexibility for custom event handling and streaming. [[1]](diffhunk://#diff-8fb995748407629acebcf81198af28867e7fa11b90b8a63e3327aff4e8bd9092R18-R25) [[2]](diffhunk://#diff-d5d89b7bafe46a42f2a021d93aa0d290839858474573097cfeff52813b519c29L280-R367)

### Event type system improvements

* Updated the `GraphEvent` class to allow its `type` field to accept either a `GraphEventType` or a custom string, supporting a broader range of event types. [[1]](diffhunk://#diff-d5d89b7bafe46a42f2a021d93aa0d290839858474573097cfeff52813b519c29L30-R31) [[2]](diffhunk://#diff-d5d89b7bafe46a42f2a021d93aa0d290839858474573097cfeff52813b519c29L42-R42)

### Callback handler interface

* Introduced the `CallbackProtocol` protocol to define the standard interface for callback handlers, improving type safety and extensibility for custom callback implementations.

### Maintenance and versioning

* Bumped the library version to `0.0.10rc3` in `pyproject.toml` to reflect these API changes.