### PR TITLE
feat: adjust parallel router logic

### DIFF
--- a/docs/user-guide/components/graphs.md
+++ b/docs/user-guide/components/graphs.md
@@ -176,5 +176,6 @@ This generates a visual representation of your graph, making it easier to unders
 ## Next Steps
 
 - Learn about [Nodes](nodes.md) to understand how to build processing units
+- Explore [Parallel Execution](parallel-execution.md) for concurrent branch processing
 - Explore [State](state.md) management for maintaining context
-- Check out [Callbacks](callbacks.md) for implementing streaming 
+- Check out [Callbacks](callbacks.md) for implementing streaming

--- a/docs/user-guide/components/parallel-execution.md
+++ b/docs/user-guide/components/parallel-execution.md
@@ -1,0 +1,314 @@
+Parallel execution allows multiple branches of your graph to run concurrently, improving performance and enabling complex workflows where independent tasks can be processed simultaneously.
+
+## Overview
+
+GraphAI supports parallel execution in two main scenarios:
+
+1. **Graph-level parallelism**: When a node has multiple outgoing edges, all successor nodes execute concurrently
+2. **Router-level parallelism**: When a router returns multiple choices, all selected branches execute concurrently
+
+## Parallel Branches with Edges
+
+When you add multiple edges from a single source node to different destination nodes, those destinations will execute in parallel.
+
+### Basic Example
+
+```python
+from graphai import Graph, node
+
+@node(start=True)
+async def start(input: dict):
+    return {}
+
+@node
+async def branch_a(input: dict):
+    return {"a": 1}
+
+@node
+async def branch_b(input: dict):
+    return {"b": 2}
+
+@node(end=True)
+async def end(input: dict):
+    return {}
+
+g = Graph()
+g.add_node(start).add_node(branch_a).add_node(branch_b).add_node(end)
+
+# Create parallel branches from start
+g.add_edge(start, branch_a)
+g.add_edge(start, branch_b)
+
+# Both branches lead to end
+g.add_edge(branch_a, end)
+g.add_edge(branch_b, end)
+
+result = await g.execute(input={"input": {}})
+# result contains: {"a": 1, "b": 2}
+```
+
+In this example, `branch_a` and `branch_b` execute concurrently after `start` completes. Their outputs are merged into the final state.
+
+### Using `add_parallel()`
+
+For convenience, you can use the `add_parallel()` method to create multiple edges at once:
+
+```python
+g = Graph()
+g.add_node(start).add_node(branch_a).add_node(branch_b).add_node(end)
+
+# Equivalent to adding edges individually
+g.add_parallel(start, [branch_a, branch_b])
+
+g.add_edge(branch_a, end)
+g.add_edge(branch_b, end)
+```
+
+## Joining Parallel Branches
+
+By default, when parallel branches converge to a common node, that node executes once for each incoming branch. To ensure the convergence node executes only once after all branches complete, use `add_join()`.
+
+### Without Join (Multiple Executions)
+
+```python
+@node(start=True)
+async def start(input: dict, state: dict):
+    state["history"] = ["start"]
+    return {}
+
+@node
+async def branch_a(input: dict, state: dict):
+    state["history"].append("branch_a")
+    return {}
+
+@node
+async def branch_b(input: dict, state: dict):
+    state["history"].append("branch_b")
+    return {}
+
+@node(end=True)
+async def end(input: dict, state: dict):
+    state["history"].append("end")
+    return {}
+
+g = Graph()
+g.add_node(start).add_node(branch_a).add_node(branch_b).add_node(end)
+g.add_edge(start, branch_a)
+g.add_edge(start, branch_b)
+g.add_edge(branch_a, end)
+g.add_edge(branch_b, end)
+
+await g.execute(input={"input": {}})
+state = g.get_state()
+# state["history"] contains TWO "end" entries because end runs for each branch
+```
+
+### With Join (Single Execution)
+
+```python
+g = Graph()
+g.add_node(start).add_node(branch_a).add_node(branch_b).add_node(end)
+g.add_edge(start, branch_a)
+g.add_edge(start, branch_b)
+
+# Use add_join to synchronize branches
+g.add_join([branch_a, branch_b], end)
+
+await g.execute(input={"input": {}})
+state = g.get_state()
+# state["history"] contains only ONE "end" entry
+```
+
+The `add_join()` method ensures that:
+- All specified branches must complete before the destination node executes
+- The destination node executes exactly once
+- State from all branches is merged before continuing
+
+## Nested Parallel Execution
+
+You can create parallel branches at multiple levels in your graph:
+
+```python
+@node(start=True)
+async def start(input: dict):
+    return {}
+
+@node
+async def mid(input: dict):
+    return {"mid": True}
+
+@node
+async def branch_a(input: dict):
+    return {"a": 1}
+
+@node
+async def branch_b(input: dict):
+    return {"b": 2}
+
+@node(end=True)
+async def end(input: dict):
+    return {}
+
+g = Graph()
+g.add_node(start).add_node(mid).add_node(branch_a).add_node(branch_b).add_node(end)
+
+# Linear edge to mid
+g.add_edge(start, mid)
+
+# Mid forks to two parallel branches
+g.add_edge(mid, branch_a)
+g.add_edge(mid, branch_b)
+
+# Both branches converge at end
+g.add_join([branch_a, branch_b], end)
+
+result = await g.execute(input={"input": {}})
+# result contains: {"mid": True, "a": 1, "b": 2}
+```
+
+## Router Parallel Execution
+
+Routers can also trigger parallel execution by returning multiple choices instead of a single choice.
+
+### Single Choice (Standard Behavior)
+
+The standard router behavior selects one branch:
+
+```python
+from graphai import router
+
+@router
+async def single_router(input: dict):
+    return {"choice": "tool_a"}  # Only tool_a executes
+```
+
+### Multiple Choices (Parallel Execution)
+
+Return `choices` (a list) instead of `choice` to execute multiple branches concurrently:
+
+```python
+@router
+async def parallel_router(input: dict):
+    return {"choices": ["tool_a", "tool_b"]}  # Both execute in parallel
+```
+
+### Full Example
+
+```python
+from graphai import Graph, node, router
+
+@node(start=True)
+async def start(input: dict):
+    return {}
+
+@router
+async def parallel_router(input: dict):
+    # Return multiple choices for parallel execution
+    return {"choices": ["tool_a", "tool_b"]}
+
+@node(name="tool_a")
+async def tool_a(input: dict):
+    return {"a_result": 1}
+
+@node(name="tool_b")
+async def tool_b(input: dict):
+    return {"b_result": 2}
+
+@node(end=True)
+async def end(input: dict):
+    return {}
+
+g = Graph()
+g.add_node(start).add_node(parallel_router).add_node(tool_a).add_node(tool_b).add_node(end)
+g.add_edge(start, parallel_router)
+g.add_edge(parallel_router, tool_a)
+g.add_edge(parallel_router, tool_b)
+g.add_join([tool_a, tool_b], end)
+
+result = await g.execute({"input": {}})
+
+# Results from parallel branches are merged into state
+assert result["a_result"] == 1
+assert result["b_result"] == 2
+```
+
+### Router with Join (Iterative Patterns)
+
+Use `add_join()` to control where execution continues after parallel branches complete. This enables iterative workflows where a router can evaluate results and decide whether to run more parallel branches:
+
+```python
+@node(start=True)
+async def start(input: dict):
+    return {}
+
+@router(name="parallel_router")
+async def parallel_router(input: dict, state: dict):
+    iteration = state.get("iteration", 0)
+
+    if iteration > 0:
+        # After first iteration, proceed to end
+        return {"choice": "end"}
+
+    state["iteration"] = iteration + 1
+    # Run tools in parallel, then return to this router via join
+    return {"choices": ["tool_a", "tool_b"]}
+
+@node(name="tool_a")
+async def tool_a(input: dict):
+    return {"a_result": 1}
+
+@node(name="tool_b")
+async def tool_b(input: dict):
+    return {"b_result": 2}
+
+@node(end=True)
+async def end(input: dict):
+    return {"final": "done"}
+
+g = Graph()
+g.add_node(start).add_node(parallel_router).add_node(tool_a).add_node(tool_b).add_node(end)
+g.add_edge(start, parallel_router)
+g.add_edge(parallel_router, tool_a)
+g.add_edge(parallel_router, tool_b)
+g.add_join([tool_a, tool_b], parallel_router)  # Return to router after parallel execution
+g.add_edge(parallel_router, end)
+
+result = await g.execute({"input": {}})
+# Router is called twice: first returns choices, second returns choice to end
+```
+
+The join pattern with routers is useful for:
+- Iterative workflows that may need multiple rounds of parallel execution
+- Gathering results from parallel branches before deciding next steps
+- Implementing tool-calling agents that can invoke multiple tools simultaneously
+
+## State Merging
+
+When parallel branches complete, their outputs are merged into the state:
+
+1. **Output merging**: Each branch's return values are merged into the final state
+2. **Conflict resolution**: If branches return the same key, the last branch to complete wins
+
+```python
+result = await g.execute({"input": {}})
+
+# Results from all branches merged into state
+result["a_result"]  # From tool_a
+result["b_result"]  # From tool_b
+```
+
+## Best Practices
+
+1. **Use `add_join()` for convergence**: When multiple branches should synchronize before continuing, always use `add_join()` to prevent duplicate execution of downstream nodes.
+
+2. **Keep parallel branches independent**: Parallel branches execute concurrently with copied state. Avoid relying on one branch's state changes being visible to another.
+
+3. **Use `add_join()` for iterative patterns**: When a router needs to make decisions after parallel execution, use `add_join()` to route back to the router node. This keeps flow control in the graph structure rather than in node return values.
+
+4. **Name nodes explicitly for routers**: When using router parallel execution, ensure destination nodes have explicit names that match the choices returned by the router.
+
+## Next Steps
+
+- Learn about [Graphs](graphs.md) for general graph construction
+- Explore [State](state.md) management for understanding how state flows through parallel branches
+- Check out [Callbacks](callbacks.md) for monitoring parallel execution progress

--- a/docs/user-guide/release-notes.md
+++ b/docs/user-guide/release-notes.md
@@ -14,10 +14,7 @@ See below for all notable changes to the GraphAI library.
   - Prevents duplicate execution of downstream nodes
 - New `add_parallel()` convenience method for creating parallel branches
   - Syntactic sugar for adding multiple edges from one source to multiple destinations
-- Parallel execution support for router nodes with multiple choices
-  - Routers can now return `choices` (list) instead of single `choice` to execute multiple branches concurrently
-  - Optional `continuation` node to resume sequential execution after parallel branches complete
-  - Results from parallel branches merged into state with `parallel_results` dictionary
+- Parallel execution support for router nodes with multiple choices by returning `choices: list[str]` rather than `choice: str`
 
 ### Changed
 - Enhanced `EventCallback.__call__()` and `EventCallback.acall()` method signatures

--- a/graphai/graph.py
+++ b/graphai/graph.py
@@ -372,53 +372,23 @@ class Graph:
                 break
             if current_node.is_router:
                 if "choices" in output:
+                    # for parallel execution, we collect next_nodes
                     choice_names = output["choices"]
-                    continuation = output.get("continuation")
                     del output["choices"]
-                    if "continuation" in output:
-                        del output["continuation"]
-
                     next_nodes = [self._get_node_by_name(name) for name in choice_names]
-
-                    results = await asyncio.gather(
-                        *[
-                            self._execute_branch(
-                                current_node=n,
-                                state=state.copy(),
-                                callback=callback,
-                                steps=steps + 1,
-                                stop_at_join=True,
-                            )
-                            for n in next_nodes
-                        ]
-                    )
-
-                    merged = state.copy()
-                    for res in results:
-                        for k, v in res.items():
-                            if k != "callback":
-                                merged[k] = v
-
-                    merged["parallel_results"] = {
-                        choice_names[i]: results[i] for i in range(len(choice_names))
-                    }
-
-                    if continuation:
-                        current_node = self._get_node_by_name(continuation)
-                        state = merged
-                        continue
-                    else:
-                        return merged
                 else:
+                    # otherwise business as usual - get the next node only
                     next_node_name = str(output["choice"])
                     del output["choice"]
                     current_node = self._get_node_by_name(node_name=next_node_name)
                     continue
+            else:
+                # for sequential execution, we can just get the next node
+                next_nodes = self._get_next_nodes(current_node)
             if stop_at_join and current_node in self.join_nodes:
                 # for parallel branches, wait at JoinEdge until all branches are complete
                 return state
 
-            next_nodes = self._get_next_nodes(current_node)
             if not next_nodes:
                 raise Exception(
                     f"No outgoing edge found for current node '{current_node.name}'."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "graphai-lib"
-version = "0.0.10rc3"
+version = "0.0.10"
 description = "Not an AI framework"
 readme = "README.md"
 requires-python = ">=3.10,<3.14"

--- a/tests/unit/test_graph_parallel.py
+++ b/tests/unit/test_graph_parallel.py
@@ -307,16 +307,21 @@ async def test_router_parallel_with_join():
     async def tool_b(input: dict):
         return {"b_result": 2}
 
+    @node(name="tool_c")
+    async def tool_c(input: dict):
+        return {"c_result": 3}
+
     @node(end=True)
     async def end(input: dict):
         return {"final": "done"}
 
     g = Graph()
-    g.add_node(start).add_node(parallel_router).add_node(tool_a).add_node(tool_b).add_node(end)
+    g.add_node(start).add_node(parallel_router).add_node(tool_a).add_node(tool_b).add_node(tool_c).add_node(end)
     g.add_edge(start, parallel_router)
     g.add_edge(parallel_router, tool_a)
     g.add_edge(parallel_router, tool_b)
-    g.add_join([tool_a, tool_b], parallel_router)
+    g.add_edge(parallel_router, tool_c)
+    g.add_join([tool_a, tool_b, tool_c], parallel_router)
     g.add_edge(parallel_router, end)
 
     result = await g.execute({"input": {}})
@@ -324,6 +329,7 @@ async def test_router_parallel_with_join():
     assert call_count["router"] == 2
     assert "a_result" in result
     assert "b_result" in result
+    assert "c_result" not in result
     assert result["final"] == "done"
 
 

--- a/tests/unit/test_graph_parallel.py
+++ b/tests/unit/test_graph_parallel.py
@@ -274,16 +274,15 @@ async def test_router_parallel_choices():
 
     result = await g.execute({"input": {}})
 
-    assert "parallel_results" in result
-    assert "tool_a" in result["parallel_results"]
-    assert "tool_b" in result["parallel_results"]
-    assert result["a_result"] == 1
-    assert result["b_result"] == 2
+    assert "tool_a" in result["choices"]
+    assert "tool_b" in result["choices"]
+    assert result.get("a_result") == 1
+    assert result.get("b_result") == 2
 
 
 @pytest.mark.asyncio
-async def test_router_parallel_with_continuation():
-    """Router with continuation should return to specified node after parallel execution."""
+async def test_router_parallel_with_join():
+    """Router with join should return to specified node after parallel execution."""
 
     call_count = {"router": 0}
 
@@ -298,7 +297,6 @@ async def test_router_parallel_with_continuation():
             return {"choice": "end"}
         return {
             "choices": ["tool_a", "tool_b"],
-            "continuation": "parallel_router",
         }
 
     @node(name="tool_a")
@@ -318,14 +316,14 @@ async def test_router_parallel_with_continuation():
     g.add_edge(start, parallel_router)
     g.add_edge(parallel_router, tool_a)
     g.add_edge(parallel_router, tool_b)
+    g.add_join([tool_a, tool_b], parallel_router)
     g.add_edge(parallel_router, end)
-    g.add_edge(tool_a, end)
-    g.add_edge(tool_b, end)
 
     result = await g.execute({"input": {}})
 
     assert call_count["router"] == 2
-    assert "parallel_results" in result
+    assert "a_result" in result
+    assert "b_result" in result
     assert result["final"] == "done"
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -437,7 +437,7 @@ wheels = [
 
 [[package]]
 name = "graphai-lib"
-version = "0.0.10rc3"
+version = "0.0.10"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
This pull request introduces comprehensive support and documentation for parallel execution in GraphAI, with a particular focus on simplifying and standardizing how router nodes trigger parallel branches. It removes the previous `continuation`-based pattern, updates the API and documentation, and adjusts tests to reflect the new approach. The changes clarify how to use parallel execution with both graph structure and routers, and ensure state merging is handled consistently.

**Parallel Execution Documentation and API Improvements:**

* Added a new user guide section (`parallel-execution.md`) detailing parallel execution, including examples for graph-level and router-level parallelism, usage of `add_parallel()` and `add_join()`, state merging, and best practices.
* Updated the main graphs documentation to reference the new parallel execution guide, making it easier for users to discover and understand concurrent branch processing.

**Router Parallel Execution Refactor:**

* Refactored router parallel execution to rely solely on returning a `choices` list (i.e., `{"choices": [...]}`) instead of the previous `continuation` pattern, simplifying the API and removing the need for a `continuation` field.
* Updated release notes and documentation to describe the new router parallel execution approach, clarifying that routers return `choices: list[str]` for concurrent branches.

**Test Suite Updates:**

* Updated tests to reflect the new router parallel execution pattern, removing assertions and logic related to the deprecated `continuation` and `parallel_results` fields, and ensuring that state merging and join behavior are correctly validated. [[1]](diffhunk://#diff-8f2d1e93becf246e5ffcad0b0b41edb2670dccc7f56c6204d61448dcd4b4bde2L277-R285) [[2]](diffhunk://#diff-8f2d1e93becf246e5ffcad0b0b41edb2670dccc7f56c6204d61448dcd4b4bde2L301) [[3]](diffhunk://#diff-8f2d1e93becf246e5ffcad0b0b41edb2670dccc7f56c6204d61448dcd4b4bde2R319-R326)